### PR TITLE
Add bulk timbrado support

### DIFF
--- a/src/app/models/Cfdi/Liquidacion.ts
+++ b/src/app/models/Cfdi/Liquidacion.ts
@@ -8,4 +8,6 @@ export interface Liquidacion {
   uuid: string | null;
   xml?: Blob | null;
   pdf?: Blob | null;
+  /** Indicador de procesamiento en UI */
+  timbrando?: boolean;
 }

--- a/src/app/shared-module/components/full-tableV2/full-table.component.html
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.html
@@ -168,6 +168,21 @@
         [dataSource]="dataSource"
         class="mat-elevation-z0"
       >
+        <ng-container *ngIf="selectable" matColumnDef="select">
+          <th mat-header-cell *matHeaderCellDef>
+            <mat-checkbox
+              [checked]="isSelectAll"
+              (change)="onCheckSelectAll($event)"
+            ></mat-checkbox>
+          </th>
+          <td mat-cell *matCellDef="let row">
+            <mat-checkbox
+              (change)="toggleRowSelection(row, $event.checked)"
+              [checked]="selectedRows.has(row)"
+            ></mat-checkbox>
+          </td>
+        </ng-container>
+
         <!-- Columnas Dinámicas -->
         <ng-container *ngFor="let column of columnKeys" [matColumnDef]="column">
           <th

--- a/src/app/ti/Components/cfdiLiquidacion/LiquidacionesConfig.ts
+++ b/src/app/ti/Components/cfdiLiquidacion/LiquidacionesConfig.ts
@@ -7,6 +7,13 @@ export const tableConfigsLiquidaciones: TableConfig = {
 };
 
 export const ColumnConfigsLiquidaciones: { [key: string]: ColumnConfig } = {
+    select: {
+        displayName: '',
+        type: 'default',
+        showFilter: false,
+        visible: true,
+        widthColumn: '40px'
+    },
     idLiquidacion: {
         displayName: 'No. Liquidación',
         type: 'default',
@@ -77,5 +84,13 @@ export const ColumnConfigsLiquidaciones: { [key: string]: ColumnConfig } = {
         rowData.uuid == null
           ? 'Sin UUID'
           : rowData.uuid,
+    },
+    estatus: {
+        displayName: 'Estatus',
+        type: 'default',
+        showFilter: false,
+        visible: true,
+        widthColumn: '100px',
+        customRender: (rowData) => rowData.timbrando ? 'Timbrando...' : ''
     }
 };

--- a/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.html
+++ b/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.html
@@ -1,8 +1,8 @@
 <app-layout titulo="Liquidaciones: Timbrado"> 
-  <app-full-tableV2 
+  <app-full-tableV2
     [fetchDataFunction]="apiCfdiLiq.getLiquidaciones.bind(apiCfdiLiq)"
-    [showCreateButtonModal]="false" 
-    [showFilterInactivos]="false" 
+    [showCreateButtonModal]="false"
+    [showFilterInactivos]="false"
     [nombreMenu]="'Liquidaciones'"
     [nombreTabla]="'Liquidaciones'" 
     [columnConfigs]="ColumnConfigsLiquidaciones"
@@ -12,7 +12,19 @@
     [mostrarFiltroGeneralFechas]="false"
     [showExportarButton]="false"
     [actions]="tableActions"
+    [selectable]="true"
+    [showSelectAll]="true"
+    (selectedRowsChange)="onSelectedRows($event)"
    >
   </app-full-tableV2>
+
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="timbrarLote()"
+    [disabled]="selectedLiquidaciones.length === 0"
+  >
+    Timbrar seleccionados
+  </button>
 
 </app-layout>

--- a/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.ts
+++ b/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { finalize } from 'rxjs/operators';
+import { forkJoin } from 'rxjs';
 import { ColumnConfigsLiquidaciones, tableConfigsLiquidaciones } from '../../LiquidacionesConfig';
 import { ApiCfdiService } from '../../../../../DataAccess/api-cfdi.service';
 import { TableAction } from '../../../../../shared-module/Interfaces/TableAction';
 import { Liquidacion } from '../../../../../models/Cfdi/Liquidacion';
-import { LoadingService } from 'src/app/Services/loading.service';
 
 @Component({
   selector: 'app-listado-liquidaciones',
@@ -15,6 +15,9 @@ export class ListadoLiquidacionesComponent implements OnInit {
   // Mapa para controlar las liquidaciones en proceso de timbrado
   private timbradoEnProceso: { [id: number]: boolean } = {};
 
+  selectedLiquidaciones: number[] = [];
+  private selectedRows: Liquidacion[] = [];
+
   descargaPdf(item: Liquidacion): void {
     throw new Error('Method not implemented.');
   }
@@ -22,21 +25,22 @@ export class ListadoLiquidacionesComponent implements OnInit {
     throw new Error('Method not implemented.');
   }
 
-  timbrarLiquidacion(idLiquidacion: number): void {
+  timbrarLiquidacion(item: Liquidacion): void {
+    const idLiquidacion = item.idLiquidacion;
     // Evitar múltiples peticiones para la misma liquidación
     if (this.timbradoEnProceso[idLiquidacion]) {
       return;
     }
 
     this.timbradoEnProceso[idLiquidacion] = true;
-    this.loading.open();
+    item.timbrando = true;
 
     this.apiCfdiLiq
       .timbrarLiquidacion(idLiquidacion)
       .pipe(
         finalize(() => {
-          this.loading.close();
           this.timbradoEnProceso[idLiquidacion] = false;
+          item.timbrando = false;
         })
       )
       .subscribe({
@@ -69,7 +73,7 @@ export class ListadoLiquidacionesComponent implements OnInit {
       title: 'Timbrar',
       icon: 'receipt_long',
       tooltip: 'Timbrar',
-      callback: (item: Liquidacion) => this.timbrarLiquidacion(item.idLiquidacion),
+      callback: (item: Liquidacion) => this.timbrarLiquidacion(item),
       showCondition: (item: Liquidacion) => !this.timbradoEnProceso[item.idLiquidacion]
 
     }
@@ -78,7 +82,35 @@ export class ListadoLiquidacionesComponent implements OnInit {
   ColumnConfigsLiquidaciones = ColumnConfigsLiquidaciones;
   tableConfigsLiquidaciones = tableConfigsLiquidaciones;
 
-  constructor(public apiCfdiLiq: ApiCfdiService, private loading: LoadingService) { }
+  constructor(public apiCfdiLiq: ApiCfdiService) { }
+
+  onSelectedRows(rows: Liquidacion[]) {
+    this.selectedRows = rows;
+    this.selectedLiquidaciones = rows.map((r) => r.idLiquidacion);
+  }
+
+  timbrarLote() {
+    if (this.selectedLiquidaciones.length === 0) return;
+
+    const requests = this.selectedRows.map((row) => {
+      this.timbradoEnProceso[row.idLiquidacion] = true;
+      row.timbrando = true;
+      return this.apiCfdiLiq.timbrarLiquidacion(row.idLiquidacion).pipe(
+        finalize(() => {
+          this.timbradoEnProceso[row.idLiquidacion] = false;
+          row.timbrando = false;
+        })
+      );
+    });
+
+    forkJoin(requests).subscribe({
+      next: () => {
+        this.selectedLiquidaciones = [];
+        this.selectedRows = [];
+      },
+      error: (err) => console.error('Error en timbrado por lote', err),
+    });
+  }
 
   ngOnInit() {
   }


### PR DESCRIPTION
## Summary
- extend Liquidacion model with `timbrando` flag
- add selection and status columns to `LiquidacionesConfig`
- enable row selection in `full-tableV2`
- add multi-select actions to Liquidaciones list
- batch timbrado requests with progress state

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532266203c832fa4be811cab1849fb