### PR TITLE
Move batch stamping button to table header

### DIFF
--- a/src/app/shared-module/components/full-tableV2/full-table.component.html
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.html
@@ -157,6 +157,7 @@
       >
         <mat-icon>settings</mat-icon>
       </button>
+      <ng-content select="[extraHeaderButtons]"></ng-content>
     </div>
   </div>
 

--- a/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.html
+++ b/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.html
@@ -4,10 +4,10 @@
     [showCreateButtonModal]="false"
     [showFilterInactivos]="false"
     [nombreMenu]="'Liquidaciones'"
-    [nombreTabla]="'Liquidaciones'" 
+    [nombreTabla]="'Liquidaciones'"
     [columnConfigs]="ColumnConfigsLiquidaciones"
-    [excelFileName]="'LiquidacionesParaTimbrado'" 
-    [isReport]="false" 
+    [excelFileName]="'LiquidacionesParaTimbrado'"
+    [isReport]="false"
     [tableConfigs]="tableConfigsLiquidaciones"
     [mostrarFiltroGeneralFechas]="false"
     [showExportarButton]="false"
@@ -15,16 +15,16 @@
     [selectable]="true"
     [showSelectAll]="true"
     (selectedRowsChange)="onSelectedRows($event)"
-   >
-  </app-full-tableV2>
-
-  <button
-    mat-raised-button
-    color="primary"
-    (click)="timbrarLote()"
-    [disabled]="selectedLiquidaciones.length === 0"
   >
-    Timbrar seleccionados
-  </button>
+    <button
+      extraHeaderButtons
+      mat-raised-button
+      color="primary"
+      (click)="timbrarLote()"
+      [disabled]="selectedLiquidaciones.length === 0"
+    >
+      Timbrar seleccionados
+    </button>
+  </app-full-tableV2>
 
 </app-layout>


### PR DESCRIPTION
## Summary
- add `extraHeaderButtons` content slot on `full-tableV2`
- move _Timbrar seleccionados_ button into the table header

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68533a553370832f9c83726b6180256d