### PR TITLE
Update selection logic for Liquidaciones

### DIFF
--- a/src/app/shared-module/components/full-tableV2/full-table.component.html
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.html
@@ -180,6 +180,7 @@
             <mat-checkbox
               (change)="toggleRowSelection(row, $event.checked)"
               [checked]="selectedRows.has(row)"
+              [disabled]="shouldBlockRow(row)"
             ></mat-checkbox>
           </td>
         </ng-container>

--- a/src/app/shared-module/components/full-tableV2/full-table.component.ts
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.ts
@@ -535,8 +535,13 @@ export class FullTableV2Component
   }
 
   toggleRowSelection(row: any, checked: boolean) {
+    if (this.shouldBlockRow(row)) {
+      return;
+    }
     if (checked) {
       this.selectedRows.add(row);
+      const eligibleRows = this.dataSource.data.filter(r => !this.shouldBlockRow(r));
+      this.isSelectAll = this.selectedRows.size === eligibleRows.length;
     } else {
       this.selectedRows.delete(row);
       this.isSelectAll = false;
@@ -737,7 +742,11 @@ console.log(items);
     this.isSelectAll = event.checked;
     if (this.selectable) {
       if (this.isSelectAll) {
-        this.dataSource.data.forEach((row) => this.selectedRows.add(row));
+        this.dataSource.data.forEach((row) => {
+          if (!this.shouldBlockRow(row)) {
+            this.selectedRows.add(row);
+          }
+        });
       } else {
         this.selectedRows.clear();
       }

--- a/src/app/ti/Components/cfdiLiquidacion/LiquidacionesConfig.ts
+++ b/src/app/ti/Components/cfdiLiquidacion/LiquidacionesConfig.ts
@@ -40,7 +40,9 @@ export const ColumnConfigsLiquidaciones: { [key: string]: ColumnConfig } = {
         type: 'number',
         showFilter: true,
         visible: true,
-        widthColumn: '10px'
+        widthColumn: '10px',
+        bloquearSeleccion: (item) =>
+            ![0, 2, 4, 5].includes(item.estatus)
     },
     mensaje: {
         displayName: 'Mensaje',


### PR DESCRIPTION
## Summary
- disable row selection for liquidaciones with disallowed status
- update FullTableV2 to handle disabled selections

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534350b374832fae67be874b097477