### PR TITLE
Update liquidacion row behaviors based on status

### DIFF
--- a/src/app/models/Cfdi/Liquidacion.ts
+++ b/src/app/models/Cfdi/Liquidacion.ts
@@ -3,6 +3,8 @@ export interface Liquidacion {
   nombre: string;
   rfc: string;
   fecha: Date;
+  estatus: number;
+  mensaje: string;
   intentos: number;
   proximoIntento: Date | null;
   uuid: string | null;

--- a/src/app/shared-module/components/full-tableV2/full-table.component.html
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.html
@@ -253,15 +253,12 @@
             </div>
           </th>
 
-          <td
-            mat-cell
-            *matCellDef="let element"
-            [ngClass]="{
-              'disabled-record': shouldBlockRow(element),
-              registroEliminado: shouldHideText(element)
-            }"
-            (click)="!shouldBlockRow(element) ? enviarItem(element) : null"
-          >
+            <td
+              mat-cell
+              *matCellDef="let element"
+              [ngClass]="{ registroEliminado: shouldHideText(element) }"
+              (click)="enviarItem(element)"
+            >
             <div *ngIf="!isLoading && !isDataEmpty">
               <ng-container *ngIf="columnConfigs[column]?.type === 'boolean'">
                 <ng-container

--- a/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.ts
+++ b/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.ts
@@ -59,14 +59,16 @@ export class ListadoLiquidacionesComponent implements OnInit {
       title: 'Descargar XML',
       icon: 'file_download',
       tooltip: 'Descarga XML',
-      callback: (item: Liquidacion) => this.descargaXml(item)
+      callback: (item: Liquidacion) => this.descargaXml(item),
+      isVisible: (item: Liquidacion) => item.estatus === 3
     },
     {
       name: 'Descarga',
       title: 'Descargar PDF',
       icon: 'file_download',
       tooltip: 'Descarga PDF',
-      callback: (item: Liquidacion) => this.descargaPdf(item)
+      callback: (item: Liquidacion) => this.descargaPdf(item),
+      isVisible: (item: Liquidacion) => item.estatus === 3
     },
     {
       name: 'Timbrar',
@@ -74,7 +76,9 @@ export class ListadoLiquidacionesComponent implements OnInit {
       icon: 'receipt_long',
       tooltip: 'Timbrar',
       callback: (item: Liquidacion) => this.timbrarLiquidacion(item),
-      showCondition: (item: Liquidacion) => !this.timbradoEnProceso[item.idLiquidacion]
+      showCondition: (item: Liquidacion) =>
+        !this.timbradoEnProceso[item.idLiquidacion],
+      isVisible: (item: Liquidacion) => [0, 2, 4, 5].includes(item.estatus)
 
     }
   ];


### PR DESCRIPTION
## Summary
- extend `Liquidacion` model with `estatus` and `mensaje`
- disable only checkbox when status not allowed without blocking the row
- hide/show table actions depending on liquidacion status

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_685345f09f8c832fb4ca3c1d86ddb63d