### PR TITLE
Fix selection clearing after batch timbrado

### DIFF
--- a/src/app/shared-module/components/full-tableV2/full-table.component.ts
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.ts
@@ -175,6 +175,14 @@ export class FullTableV2Component
     this.selectedRowsChange.emit(Array.from(this.selectedRows));
   }
 
+  clearSelection(): void {
+    if (this.selectable) {
+      this.selectedRows.clear();
+      this.isSelectAll = false;
+      this.emitSelectedRows();
+    }
+  }
+
   constructor(
     private excelService: ExportTableExcelService,
     public dialog: MatDialog,

--- a/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.html
+++ b/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.html
@@ -1,5 +1,6 @@
 <app-layout titulo="Liquidaciones: Timbrado"> 
   <app-full-tableV2
+    #fullTable
     [fetchDataFunction]="apiCfdiLiq.getLiquidaciones.bind(apiCfdiLiq)"
     [showCreateButtonModal]="false"
     [showFilterInactivos]="false"

--- a/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.ts
+++ b/src/app/ti/Components/cfdiLiquidacion/Listado-liquidaciones/listado-liquidaciones/listado-liquidaciones.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { finalize } from 'rxjs/operators';
 import { forkJoin } from 'rxjs';
 import { ColumnConfigsLiquidaciones, tableConfigsLiquidaciones } from '../../LiquidacionesConfig';
 import { ApiCfdiService } from '../../../../../DataAccess/api-cfdi.service';
 import { TableAction } from '../../../../../shared-module/Interfaces/TableAction';
 import { Liquidacion } from '../../../../../models/Cfdi/Liquidacion';
+import { FullTableV2Component } from '../../../../../shared-module/components/full-tableV2/full-table.component';
 
 @Component({
   selector: 'app-listado-liquidaciones',
@@ -14,6 +15,8 @@ import { Liquidacion } from '../../../../../models/Cfdi/Liquidacion';
 export class ListadoLiquidacionesComponent implements OnInit {
   // Mapa para controlar las liquidaciones en proceso de timbrado
   private timbradoEnProceso: { [id: number]: boolean } = {};
+
+  @ViewChild('fullTable') fullTable!: FullTableV2Component;
 
   selectedLiquidaciones: number[] = [];
   private selectedRows: Liquidacion[] = [];
@@ -111,6 +114,7 @@ export class ListadoLiquidacionesComponent implements OnInit {
       next: () => {
         this.selectedLiquidaciones = [];
         this.selectedRows = [];
+        this.fullTable.clearSelection();
       },
       error: (err) => console.error('Error en timbrado por lote', err),
     });


### PR DESCRIPTION
## Summary
- add `clearSelection` method to `FullTableV2Component`
- expose table component in `ListadoLiquidacionesComponent`
- clear checkboxes after batch timbrado completes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685348f76238832fa493a50119668c74