### PR TITLE
Add icon-based status column

### DIFF
--- a/src/app/shared-module/components/full-tableV2/full-table.component.html
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.html
@@ -417,6 +417,15 @@
                 </ng-template>
               </ng-container>
 
+              <ng-container *ngIf="columnConfigs[column]?.type === 'icon'">
+                <mat-icon
+                  [ngStyle]="{ color: getIconData(element, column).color }"
+                  matTooltip="{{ getIconData(element, column).tooltip }}"
+                >
+                  {{ getIconData(element, column).icon }}
+                </mat-icon>
+              </ng-container>
+
               <ng-container *ngIf="columnConfigs[column]?.type === 'select'">
                 <select
                   [(ngModel)]="element[column]"

--- a/src/app/shared-module/components/full-tableV2/full-table.component.ts
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.ts
@@ -676,6 +676,22 @@ export class FullTableV2Component
     return row.activo === false; // Por ejemplo, oculta el texto para los registros no activos
   }
 
+  getIconData(element: any, column: string): { icon: string; color: string; tooltip: string } {
+    let rawValue = '';
+    if (this.columnConfigs[column]?.customRender) {
+      rawValue = this.columnConfigs[column].customRender(element);
+    } else {
+      rawValue = element[column];
+    }
+
+    const parts = typeof rawValue === 'string' ? rawValue.split(',') : [];
+    return {
+      icon: parts[0]?.trim() || '',
+      color: parts[1]?.trim() || '',
+      tooltip: parts.slice(2).join(',').trim(),
+    };
+  }
+
   loadData = () => {
     if (this.formularioModificado) {
       this.originalData = [];

--- a/src/app/ti/Components/cfdiLiquidacion/LiquidacionesConfig.ts
+++ b/src/app/ti/Components/cfdiLiquidacion/LiquidacionesConfig.ts
@@ -37,12 +37,41 @@ export const ColumnConfigsLiquidaciones: { [key: string]: ColumnConfig } = {
     },
     estatus: {
         displayName: 'Estatus',
-        type: 'number',
+        type: 'icon',
         showFilter: true,
         visible: true,
         widthColumn: '10px',
         bloquearSeleccion: (item) =>
-            ![0, 2, 4, 5].includes(item.estatus)
+            ![0, 2, 4, 5].includes(item.estatus),
+        customRender: (rowData) => {
+            let icon = 'error';
+            let color = 'red';
+            let tooltip = rowData.mensaje || 'Timbrado Fallido';
+            switch (rowData.estatus) {
+                case 0:
+                    icon = 'radio_button_unchecked';
+                    color = 'gray';
+                    tooltip = rowData.mensaje || 'Sin timbrar';
+                    break;
+                case 1:
+                    icon = 'autorenew';
+                    color = 'blue';
+                    tooltip = rowData.mensaje || 'En proceso de timbrado';
+                    break;
+                case 3:
+                    icon = 'check_circle';
+                    color = 'green';
+                    tooltip = rowData.mensaje || 'Liquidacion timbrada exitosamente';
+                    break;
+                default:
+                    // estatus 2,4,5 o cualquier otro valor
+                    icon = 'error';
+                    color = 'red';
+                    tooltip = rowData.mensaje || 'Timbrado Fallido';
+                    break;
+            }
+            return `${icon},${color},${tooltip}`;
+        }
     },
     mensaje: {
         displayName: 'Mensaje',


### PR DESCRIPTION
## Summary
- show icons for Liquidaciones status values
- add icon tooltip capability to full-table component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534b94708c832f8fdb94e7bf274792