### PR TITLE
Show spinner in timbrado status

### DIFF
--- a/src/app/shared-module/components/full-tableV2/full-table.component.html
+++ b/src/app/shared-module/components/full-tableV2/full-table.component.html
@@ -418,12 +418,17 @@
               </ng-container>
 
               <ng-container *ngIf="columnConfigs[column]?.type === 'icon'">
-                <mat-icon
-                  [ngStyle]="{ color: getIconData(element, column).color }"
-                  matTooltip="{{ getIconData(element, column).tooltip }}"
-                >
-                  {{ getIconData(element, column).icon }}
-                </mat-icon>
+                <ng-container *ngIf="getIconData(element, column).icon === 'spinner'; else showIcon">
+                  <mat-spinner diameter="20"></mat-spinner>
+                </ng-container>
+                <ng-template #showIcon>
+                  <mat-icon
+                    [ngStyle]="{ color: getIconData(element, column).color }"
+                    matTooltip="{{ getIconData(element, column).tooltip }}"
+                  >
+                    {{ getIconData(element, column).icon }}
+                  </mat-icon>
+                </ng-template>
               </ng-container>
 
               <ng-container *ngIf="columnConfigs[column]?.type === 'select'">

--- a/src/app/ti/Components/cfdiLiquidacion/LiquidacionesConfig.ts
+++ b/src/app/ti/Components/cfdiLiquidacion/LiquidacionesConfig.ts
@@ -44,6 +44,9 @@ export const ColumnConfigsLiquidaciones: { [key: string]: ColumnConfig } = {
         bloquearSeleccion: (item) =>
             ![0, 2, 4, 5].includes(item.estatus),
         customRender: (rowData) => {
+            if (rowData.timbrando) {
+                return `spinner,blue,Timbrando...`;
+            }
             let icon = 'error';
             let color = 'red';
             let tooltip = rowData.mensaje || 'Timbrado Fallido';
@@ -115,13 +118,5 @@ export const ColumnConfigsLiquidaciones: { [key: string]: ColumnConfig } = {
             rowData.uuid == null
                 ? 'Sin UUID'
                 : rowData.uuid,
-    },
-    estatus2: {
-        displayName: 'Estatus',
-        type: 'default',
-        showFilter: false,
-        visible: true,
-        widthColumn: '100px',
-        customRender: (rowData) => rowData.timbrando ? 'Timbrando...' : ''
     }
 };


### PR DESCRIPTION
## Summary
- replace textual status column with spinner in icon column
- support spinner rendering in generic table

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534e09213c832f96bae029b88d9a70