### PR TITLE
Show liquidacion timbrado errors

### DIFF
--- a/src/app/models/Cfdi/Liquidacion.ts
+++ b/src/app/models/Cfdi/Liquidacion.ts
@@ -12,4 +12,6 @@ export interface Liquidacion {
   pdf?: Blob | null;
   /** Indicador de procesamiento en UI */
   timbrando?: boolean;
+  /** Errores devueltos al intentar timbrar */
+  errores?: string[];
 }


### PR DESCRIPTION
## Summary
- store API errors in `Liquidacion`
- display a new action to view errors and update status after timbrar

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853567610c4832fa0cb85015293bd32